### PR TITLE
Network pane

### DIFF
--- a/src/provisioner/cli/common.py
+++ b/src/provisioner/cli/common.py
@@ -36,16 +36,6 @@ def regular_text(text: str):
     return click.style(text, fg="", bg="")
 
 
-def padding(text: str, size: int, *, on_end: bool = False) -> str:
-    tl = len(text)
-    if tl > size:
-        return text[:size]
-    elif tl < size:
-        pad = (size - tl) * " "
-        return f"{text}{pad}" if on_end else f"{pad}{text}"
-    return text
-
-
 def refresh(host: ProvisionHost):
     with Halo(text="Gathering Host information", spinner="line") as spinner:
         host.query_all()

--- a/src/provisioner/cli/provision.py
+++ b/src/provisioner/cli/provision.py
@@ -3,14 +3,14 @@ import questionary
 from halo import Halo
 from log_symbols.symbols import LogSymbols
 
-from provisioner.cli.common import CliResult, padding
+from provisioner.cli.common import CliResult
 from provisioner.cli.provision_manual import main as main_prog
 from provisioner.constants import RC_CANCELED
 from provisioner.context import Context
 from provisioner.host import ProvisionHost
 from provisioner.utils.blk.devices import Disk
 from provisioner.utils.imgprobe import ImageFileInfo
-from provisioner.utils.misc import format_size
+from provisioner.utils.misc import format_size, padding
 
 context = Context.get()
 logger = context.logger
@@ -18,6 +18,7 @@ logger = context.logger
 CLEAR_LINE: str = Halo.CLEAR_LINE
 SUCC = LogSymbols.SUCCESS.value
 ERR = LogSymbols.ERROR.value
+
 
 def main(host: ProvisionHost) -> CliResult:
 
@@ -50,7 +51,7 @@ def main(host: ProvisionHost) -> CliResult:
         return CliResult(code=RC_CANCELED)
     image = host.dev.images[image_index]
     image_device = host.dev.get_disk_from_name(image.device)
-    image_phy_disk = getattr(image_device, "disk") or image_device
+    image_phy_disk = image_device.disk or image_device
 
     click.echo("Image: ", nl=False)
     click.secho(image.linux.release, fg="magenta", nl=False)
@@ -100,9 +101,9 @@ def main(host: ProvisionHost) -> CliResult:
         return CliResult(code=RC_CANCELED)
 
     return main_prog(
-            source_device_path=image_device.path,
-            source_image_path=image.relpath,
-            target=target_disk.path,
-        )
+        source_device_path=image_device.path,
+        source_image_path=image.relpath,
+        target=target_disk.path,
+    )
 
     return CliResult(code=0)

--- a/src/provisioner/cli/status.py
+++ b/src/provisioner/cli/status.py
@@ -8,7 +8,6 @@ from prettytable import PrettyTable, TableStyle
 from provisioner.cli.common import (
     CliResult,
     error_text,
-    padding,
     refresh,
     regular_text,
     success_text,
@@ -18,7 +17,7 @@ from provisioner.constants import WL_IFACE
 from provisioner.context import Context
 from provisioner.host import ProvisionHost
 from provisioner.utils.blk.manager import BlockDevicesManager
-from provisioner.utils.misc import format_dt, format_size, yesno
+from provisioner.utils.misc import format_dt, format_size, padding, yesno
 from provisioner.utils.network import Interface, InternetCheckResult
 from provisioner.utils.raspberry import BootValue
 

--- a/src/provisioner/constants.py
+++ b/src/provisioner/constants.py
@@ -1,4 +1,3 @@
-
 NAME = "kiwix-provisioner"  # must be filesystem-friendly (technical)
 NAME_CLI = "provisioner"
 NAME_HUMAN = "Hotspot Provisioner"
@@ -113,4 +112,6 @@ ASCII_LOGO = r"""
 ▐░▌       ▐░▌▐░█▄▄▄▄▄▄▄█░▌     ▐░▌      ▄▄▄▄▄▄▄▄▄█░▌▐░▌          ▐░█▄▄▄▄▄▄▄█░▌     ▐░▌     
 ▐░▌       ▐░▌▐░░░░░░░░░░░▌     ▐░▌     ▐░░░░░░░░░░░▌▐░▌          ▐░░░░░░░░░░░▌     ▐░▌     
  ▀         ▀  ▀▀▀▀▀▀▀▀▀▀▀       ▀       ▀▀▀▀▀▀▀▀▀▀▀  ▀            ▀▀▀▀▀▀▀▀▀▀▀       ▀      
-""".strip("\n")
+""".strip(
+    "\n"
+)

--- a/src/provisioner/context.py
+++ b/src/provisioner/context.py
@@ -59,9 +59,11 @@ class Context:
             level=logging.DEBUG if debug else logging.INFO,
             format="%(asctime)s %(levelname)s | %(message)s",
         )
+
         def handle_exc(msg, *args, **kwargs):
             cls.logger.debug(msg, *args, exc_info=True, **kwargs)
-        cls.logger.exception =handle_exc
+
+        cls.logger.exception = handle_exc
 
     @classmethod
     def get(cls) -> "Context":

--- a/src/provisioner/entrypoints/script.py
+++ b/src/provisioner/entrypoints/script.py
@@ -39,5 +39,6 @@ def main() -> int:
             return ps.returncode
     return 0
 
+
 def entrypoint():
     sys.exit(main())

--- a/src/provisioner/provisioning/offspotyaml.py
+++ b/src/provisioner/provisioning/offspotyaml.py
@@ -9,6 +9,7 @@ from provisioner.utils.yaml import yaml_dump, yaml_load
 context = Context.get()
 logger = context.logger
 
+
 class OffspotYAMLStep(Step):
 
     ident: str = "offspot"

--- a/src/provisioner/tui/app.py
+++ b/src/provisioner/tui/app.py
@@ -155,6 +155,6 @@ def main() -> int:
     signal.signal(signal.SIGINT, exit_gracefully)
     signal.signal(signal.SIGQUIT, exit_gracefully)
 
-    app.start(pane="network")
+    app.start(pane="loading")
 
     return app.exit_code

--- a/src/provisioner/tui/app.py
+++ b/src/provisioner/tui/app.py
@@ -27,10 +27,9 @@ def _exception_handler(loop, context):
             + "".join(traceback.format_tb(exception.__traceback__))
         )
         # self.chatbox = LoadingChatBox(message)
-    except Exception as exc:
+    except Exception:
         ...
         # self.chatbox = LoadingChatBox('Unable to show exception: ' + str(exc))
-    return
 
 
 class ExceptionHandlingLoop(uw.AsyncioEventLoop):
@@ -47,7 +46,7 @@ class App:
     palette = (
         # name, foreground, background, mono, foreground_high, background_high
         ("banner", "", "", "", "#ffa", "#FD5"),
-        ("streak", "", "", "", "white", "#f70"),
+        ("streak", "", "", "", "white,bold", "#f70"),
         ("inside", "", "", "", "", "#EB2"),
         ("outside", "", "", "", "", "#FD5"),
         ("bg", "", "", "", "", "#f70"),
@@ -70,12 +69,19 @@ class App:
         ("popup_confirm_btn_focus", "", "", "", "white", "#1bf"),
         ("popup_confirm_btn_lines", "", "", "", "black", "#1bf"),
         ("popup_confirm_btn_lines_focus", "", "", "", "white", "#1bf"),
+        ("excelent-signal", "", "", "", "#008300", "#f70"),
+        ("great-signal", "", "", "", "#008300", "#f70"),
+        ("correct-signal", "", "", "", "#ffff00", "#f70"),
+        ("poor-signal", "", "", "", "#ff0000", "#f70"),
+        ("bad-signal", "", "", "", "#ff0000", "#f70"),
+        ("success-status", "", "", "", "#008300,bold", "#f70"),
+        ("error-status", "", "", "", "#f00", "#f70"),
     )
 
     def __init__(self) -> None:
         self.exit_code = 1
         self.host = ProvisionHost()
-        self.placeholder = uw.SolidFill("bg")
+        self.placeholder = uw.SolidFill()
         self.custom_loop = ExceptionHandlingLoop(loop=aio_loop)
         self.custom_loop.set_exception_handler(_exception_handler)
         self.uloop = uw.MainLoop(
@@ -96,7 +102,7 @@ class App:
             if self.uloop:
                 aio_loop.stop()
                 self.uloop.stop()
-        print(f"Received {key=}", flush=True)
+        # print(f"Received {key=}", flush=True)
 
     def reset_ui(self):
         self.uloop.widget = uw.AttrMap(self.placeholder, "bg")
@@ -108,9 +114,12 @@ class App:
         self.reset_ui()
         self.update()
         from provisioner.tui.loading import LoadingPane
+        from provisioner.tui.network import NetworkPane
         from provisioner.tui.pane import ExitPane
 
-        self.pane = {"loading": LoadingPane, "exit": ExitPane}[pane](self)
+        self.pane = {"loading": LoadingPane, "exit": ExitPane, "network": NetworkPane}[
+            pane
+        ](self)
 
     def update(self):
         try:
@@ -146,6 +155,6 @@ def main() -> int:
     signal.signal(signal.SIGINT, exit_gracefully)
     signal.signal(signal.SIGQUIT, exit_gracefully)
 
-    app.start(pane="loading")
+    app.start(pane="network")
 
     return app.exit_code

--- a/src/provisioner/tui/boxbutton.py
+++ b/src/provisioner/tui/boxbutton.py
@@ -5,6 +5,7 @@ import urwid as uw
 if typing.TYPE_CHECKING:
     from urwid.widget.popup import PopUpParametersModel
 else:
+
     class PopUpParametersModel(dict): ...
 
 

--- a/src/provisioner/tui/loading.py
+++ b/src/provisioner/tui/loading.py
@@ -5,7 +5,7 @@ from threading import Thread
 
 import urwid as uw
 
-from provisioner.constants import ASCII_LOGO, RC_ADVANCED, RC_REBOOT, RC_HALT
+from provisioner.constants import ASCII_LOGO, RC_ADVANCED, RC_HALT, RC_REBOOT
 from provisioner.host import ProvisionHost
 from provisioner.tui.boxbutton import BoxButton, ConfirmingBoxButton
 from provisioner.tui.pane import Pane
@@ -78,6 +78,14 @@ class LoadingPane(Pane):
             f"S/N: {self.host.serial_number.upper()}"
         )
         self.update()
+        warning = "" if self.host.network.all_good else "⚠️  "
+        self.menu.contents.insert(
+            0,
+            (
+                BoxButton(f"{warning}Network", self.on_network_selected),
+                (uw.WHSettings.WEIGHT, 25, True),
+            ),
+        )
         self.menu.contents.insert(
             0,
             (
@@ -90,6 +98,9 @@ class LoadingPane(Pane):
 
     def on_provision_selected(self, arg):
         print(f"PROV: {arg}")
+
+    def on_network_selected(self, arg):
+        self.app.switch_to("network")
 
     def on_restart_selected(self, arg):
         self.app.stop(exit_code=RC_REBOOT)

--- a/src/provisioner/tui/network.py
+++ b/src/provisioner/tui/network.py
@@ -1,0 +1,341 @@
+import functools
+import time
+from collections.abc import Hashable
+from threading import Thread
+from typing import ClassVar
+
+import urwid as uw
+from nmcli import connection as nmconn
+from nmcli import device as nmdevice
+
+from provisioner.constants import ETH_IFACE, WL_IFACE
+from provisioner.tui.pane import Pane
+from provisioner.tui.spinner import SpinnerText
+from provisioner.utils.misc import run_step_command
+from provisioner.utils.network import WiFiNetwork, apply_dhcp
+
+
+def text_for(net: WiFiNetwork) -> list[str | tuple[Hashable, str]]:
+    connected = "[Connected] " if net.connected else ""
+    return [
+        (f"{net.signal_code}-signal", f"{net.signal_symbol} "),
+        f"{connected}{net.name} – "  # noqa: RUF001
+        f"{net.security} ({net.freq})",
+    ]
+
+
+class DoneEdit(uw.Edit):
+    _metaclass_ = uw.signals.MetaSignals
+    signals: ClassVar = ["done"]
+
+    def keypress(self, size, key):
+        if key == "enter":
+            uw.emit_signal(self, "done", self, self.get_edit_text())
+            super().set_edit_text("")
+            return
+        elif key == "esc":
+            super().set_edit_text("")
+            return
+        uw.Edit.keypress(self, size, key)
+
+
+class NetworkPane(Pane):
+
+    @property
+    def std_option(self):
+        return (uw.WHSettings.WEIGHT, 10)
+
+    def reset(self):
+        self.app.switch_to("network")
+
+    def render(self):
+        # paint solid background with vertical stack
+        self.main_widget = uw.Filler(uw.Pile([], focus_item=1), valign="top")
+        pile = self.main_widget.base_widget  # .base_widget skips the decorations
+
+        # paint a text line surrounded by two lines of decor
+        div = uw.Divider()
+        outside = uw.AttrMap(div, "outside")
+        inside = uw.AttrMap(div, "inside")
+        streak = uw.AttrMap(
+            uw.Text("Configure networking", align=uw.Align.CENTER), "streak"
+        )
+        for item in [outside, inside, streak, inside, outside, uw.Divider()]:
+            pile.contents.append((item, pile.options()))
+
+        self.update()
+        # re-query network to get an accurate, up-to-date status
+        self.host.query_network()
+
+        self.statuses_entry = (
+            uw.Padding(
+                self.get_statuses(),
+                align=uw.Align.CENTER,
+                width=(uw.WHSettings.RELATIVE, 50),
+                min_width=50,
+            ),
+            self.std_option,
+        )
+        pile.contents.append(self.statuses_entry)
+
+        self.loading_text = SpinnerText(
+            "Looking for wireless networks…", align="center"
+        )
+        self.menu = uw.Pile(
+            [
+                (
+                    *self.std_option,
+                    uw.Button("Cancel and go back", on_press=self.on_cancel),
+                ),
+                (*self.std_option, self.loading_text),
+            ]
+        )
+        decorated_menu = uw.Padding(
+            self.menu,
+            align=uw.Align.CENTER,
+            width=(uw.WHSettings.RELATIVE, 50),
+            min_width=50,
+        )
+        pile.contents.append((decorated_menu, self.std_option))
+        pile.focus_item = decorated_menu
+
+        # request spinner text to animate
+        self.loading_text.animate(self.uloop)
+
+        self.update()
+
+        # start thread gathering infos from host
+        Thread(target=self.gather_infos).start()
+
+    def get_statuses(self) -> uw.Pile:
+        internet = self.host.network.internet
+        internet_text = [
+            "Internet: ",
+            (
+                "success-status" if internet.https else "error-status",
+                internet.status,
+            ),
+        ]
+        if internet.public_ip:
+            internet_text += [f" – IP: {internet.public_ip}"]
+
+        eth0 = self.host.network.ifaces[ETH_IFACE]
+        wlan0 = self.host.network.ifaces[WL_IFACE]
+        connected_text: list[str | tuple[Hashable, str]] = []
+        if eth0.connected and wlan0.connected:
+            connected_text += [
+                "🚫 Both Ethernet and WiFi are connected. ",
+                "This is unreliable. ",
+                "Please configure one",
+            ]
+        elif eth0:
+            connected_text += [
+                f"✅ Connected via Ethernet (wired) – IP: {eth0.ip4_address}"
+            ]
+        elif wlan0:
+            connected_text += [
+                f"✅ Connected via WiFi “{wlan0.name}” – IP: {eth0.ip4_address}"
+            ]
+        else:
+            connected_text += [
+                "🚫 Neither Ethernet nor WiFi connected. Please configure one"
+            ]
+
+        pile = uw.Pile(
+            [
+                uw.Text(internet_text, align=uw.Align.LEFT),
+                uw.Text(connected_text, align=uw.Align.LEFT),
+                uw.Divider(),
+            ]
+        )
+        return pile
+
+    def remove_statuses(self):
+        pile = self.main_widget.base_widget
+        pile.contents.remove(self.statuses_entry)
+
+    def add_to_menu(self, entry):
+        self.menu.contents.append(entry)
+
+    def gather_infos(self):
+        # TODO: check if WiFI is blocked.
+        # if so, unblock and requery network
+        eth0 = self.host.network.ifaces[ETH_IFACE]
+        wlan0 = self.host.network.ifaces[WL_IFACE]
+        if not wlan0.available:
+            run_step_command(["rfkill", "unblock", "wifi"], check=True)
+            run_step_command(["iw", "reg", "set", "FR"], check=True)
+            run_step_command(["nmcli", "radio", "wifi", "on"], check=True)
+            # make sure interface is ready to scan
+            time.sleep(3)
+
+        wifi_conf = nmdevice.wifi(ifname=WL_IFACE, rescan=True)
+        # when connected, if usually returns just the connected network
+        if len(wifi_conf) and wifi_conf[0].in_use:
+            nmdevice.disconnect(ifname=WL_IFACE)
+            wifi_conf = nmdevice.wifi(ifname=WL_IFACE, rescan=True)
+            nmdevice.connect(ifname=WL_IFACE)
+
+        self.networks = {dev.bssid: WiFiNetwork(dev) for dev in wifi_conf}
+        self.loading_text.done("")
+        # self.menu.contents.pop()
+
+        self.add_to_menu(
+            (
+                uw.Text("Please choose a networking method:", align=uw.Align.CENTER),
+                self.std_option,
+            )
+        )
+        self.add_to_menu((uw.Divider(), self.std_option))
+        self.add_to_menu(
+            (uw.Text(f"Wired connection (HW: {eth0.hwaddr})"), self.std_option)
+        )
+        self.add_to_menu((uw.Divider(), self.std_option))
+        self.add_to_menu(
+            (
+                uw.Button("      Ethernet", on_press=self.on_ethernet_selected),
+                self.std_option,
+            )
+        )
+        self.add_to_menu((uw.Divider(), self.std_option))
+        self.add_to_menu(
+            (uw.Text(f"Wireless networks (HW: {wlan0.hwaddr})"), self.std_option)
+        )
+
+        self.update()
+
+        for net in self.networks.values():
+            self.add_to_menu(
+                (
+                    uw.Button(
+                        label=text_for(net),
+                        on_press=functools.partial(self.on_wifi_selected, net.ident),
+                    ),
+                    self.std_option,
+                )
+            )
+        self.update()
+
+    def on_error(self, message: str = ""):
+        self.menu.contents.clear()
+        self.add_to_menu(
+            (uw.Text(f"❌ {message}", align=uw.Align.CENTER), self.std_option),
+        )
+        self.add_to_menu(
+            (
+                uw.Button("OK", lambda _: self.reset()),
+                self.std_option,
+            )
+        )
+        self.menu.focus_position = len(self.menu.contents) - 1
+        self.update()
+
+    def on_success(self, message: str = ""):
+        self.statuses = self.get_statuses()
+        self.menu.contents.clear()
+        self.add_to_menu(
+            (uw.Text(f"✅ {message}", align=uw.Align.CENTER), self.std_option)
+        )
+        self.add_to_menu(
+            (
+                uw.Button("OK", lambda _: self.app.switch_to("loading")),
+                self.std_option,
+            )
+        )
+        self.menu.focus_position = len(self.menu.contents) - 1
+        self.update()
+
+    def on_ethernet_selected(self, *args):
+        self.remove_statuses()
+        self.menu.contents.clear()
+        spinner = SpinnerText("Configuring network for Ethernet…")
+        self.add_to_menu((spinner, self.std_option))
+        spinner.animate(self.uloop)
+        self.update()
+
+        res = apply_dhcp(iface=ETH_IFACE)
+        if not res.success:
+            return self.on_error("Failed to connect Ethernet. Reboot and retry.")
+        try:
+            nmdevice.connect(ifname=ETH_IFACE)
+        except Exception:
+            return self.on_error("Failed to connect Ethernet. Reboot and retry.")
+
+        # disconnect WiFi
+        if (
+            self.host.network.ifaces[WL_IFACE].connected
+            and self.host.network.ifaces[WL_IFACE].connection
+        ):
+            try:
+                nmconn.delete(name=self.host.network.ifaces[WL_IFACE].connection)
+            except Exception:
+                ...
+
+        self.on_success("Ethernet now configured (DHCP)")
+
+    def on_wifi_selected(self, ident: str, *args):
+        self.remove_statuses()
+        self.menu.contents.clear()
+        self.network = self.networks[ident]
+
+        if not self.network.dev.security:
+            return self.on_passphrase_set(None, None)
+
+        self.passphrase_field = DoneEdit(
+            f"Type in passphrase for Network {self.network.name} "
+            f"{self.network.security} ({self.network.freq}) ",
+            "",
+        )
+        uw.connect_signal(self.passphrase_field, "done", self.on_passphrase_set)
+
+        self.add_to_menu(
+            (self.passphrase_field, self.std_option),
+        )
+        self.update()
+
+    def on_passphrase_set(
+        self, _edit: uw.Edit | None, new_edit_text: str | None
+    ) -> None:
+        self.menu.contents.clear()
+        self.loading_text.set_message(
+            f"Connecting to {self.network.name} using “{new_edit_text}”…"
+            if new_edit_text is not None
+            else f"Connecting to {self.network.name}…"
+        )
+        self.add_to_menu((self.loading_text, self.std_option))
+        self.loading_text.animate(self.uloop)
+        self.update()
+        Thread(
+            target=self.connect_to_wifi, kwargs={"password": new_edit_text or ""}
+        ).start()
+
+    def connect_to_wifi(self, password: str):
+        try:
+            nmdevice.wifi_connect(ssid=self.network.bssid, password=password)
+        except Exception:
+            self.loading_text.done("")
+            return self.on_error(
+                f"Failed to connect to {self.network.name}. "
+                "Was the passphrase correct?"
+            )
+        else:
+            time.sleep(2)
+
+        res = apply_dhcp(iface=WL_IFACE)
+        if not res.success:
+            self.loading_text.done("")
+            return self.on_error(
+                f"Failed to get an IP address from {self.network.name}"
+            )
+
+        # disconnect Ethernet
+        try:
+            nmconn.delete(name=self.host.network.ifaces[ETH_IFACE].connection)
+        except Exception:
+            raise
+
+        self.loading_text.done("")
+        return self.on_success(f"WiFi now configured: {self.network.name}")
+
+    def on_cancel(self, *args):
+        self.app.switch_to("loading")

--- a/src/provisioner/tui/pane.py
+++ b/src/provisioner/tui/pane.py
@@ -6,7 +6,7 @@ from provisioner.tui.app import App
 class Pane:
     def __init__(self, app: App) -> None:
         self.app = app
-        self.main_widget : uw.Widget = self.app.placeholder
+        self.main_widget: uw.Widget = self.app.placeholder
         self.render()
         self.uloop.widget.original_widget = self.main_widget
 

--- a/src/provisioner/tui/spinner.py
+++ b/src/provisioner/tui/spinner.py
@@ -30,8 +30,12 @@ class SpinnerText(uw.Text):
     def next_frame(self):
         self.set_text(self.get_next())
 
+    def set_message(self, message: str):
+        self._message = message
+
     def animate(self, loop: uw.MainLoop):
         self.loop = loop
+        self.is_loading = True
 
         async def animator():
             def update(*args):

--- a/src/provisioner/utils/blk/manager.py
+++ b/src/provisioner/utils/blk/manager.py
@@ -42,7 +42,6 @@ class BlockDevicesManager:
         self.disks = get_disks_from_devices(get_devices())
         self.images = self.get_images()
 
-
     def get_disk_from_path(self, path: Path) -> Device:
         for disk in self.disks.values():
             if disk.path == path:

--- a/src/provisioner/utils/misc.py
+++ b/src/provisioner/utils/misc.py
@@ -49,6 +49,16 @@ def run_command(args: list[str]) -> CompletedProcess[str]:
     )
 
 
+def padding(text: str, size: int, *, on_end: bool = False) -> str:
+    tl = len(text)
+    if tl > size:
+        return text[:size]
+    elif tl < size:
+        pad = (size - tl) * " "
+        return f"{text}{pad}" if on_end else f"{pad}{text}"
+    return text
+
+
 def find_file(under: Path, named: str) -> Path:
     try:
         return next(under.rglob(named))


### PR DESCRIPTION
Added a network pane in regular mode that allows configuring
network (only simple, regular use cases):

- Option appears after host-info so it's populated (and we dont have to cancel thread)
- Option has a warning sign if network is not OK
- Displays information about current network:
  - Internet connection status with IP (that's what we ultimately want to know)
  - Current connection: ethernet or WiFi with IP (simple feedback on config)
- List the available wired and wireless options to choose from
- Shows mac address of ifaces as mac-whitelisting is very common

Upon Ethernet connection request:
- request DHCP
- up the connection
- disconnect WiFi

Upon WiFi connection request:
- Ask for passphrase
- Connect to network
- Request DHCP
- Disconnect Ethernet

If anything fails, an error message is shown and user is taken back to
the network pane

If it worked, a confirmation message is shown and user is taken back Home

Fixes #25